### PR TITLE
Add functionality to send system metrics to Grafana

### DIFF
--- a/src/app/SendToGrafana.lua
+++ b/src/app/SendToGrafana.lua
@@ -1,6 +1,4 @@
 -- ! Modules 
---dofile('wifiinit.lua')
---dofilerequire('credentials.lua')
 require('credentials')
 
 -- ! Local Variables 
@@ -11,20 +9,8 @@ local url = SERVER
 ------------------------------------------------------------------------------------
 -- ! @function create_grafana_message    to read the data from the bme sensor 
 -- !                                     and send it by post request 
---                                               
--- ! @var temperature                    stores the temperature returned by the internal
--- !                                     function of sensor
---
--- ! @var humidity                       stores the humidity returned by the internal 
--- !                                     function of sensor
---
--- ! @var pressure                       stores the pressure returned by the internal
--- !                                     function of sensor
---
--- ! @var INICIALES                      user's initials, brought from credential.lua  
---
--- ! @var time							 time in nanosecconds since 
 ------------------------------------------------------------------------------------
+
 function create_grafana_message(temperature,humidity,pressure,INICIALES,time)
 	local data = "mediciones,device=" .. INICIALES .. " temp=" ..
 									temperature .. ",hum=" .. humidity .. ",press=" .. pressure .." " .. time
@@ -36,17 +22,6 @@ end
 ------------------------------------------------------------------------------------
 -- ! @function send_data_grafana         to read the data from the bme sensor 
 -- !                                     and send it by post request 
---                                               
--- ! @var temperature                    stores the temperature returned by the internal
--- !                                     function of sensor
---
--- ! @var humidity                       stores the humidity returned by the internal 
--- !                                     function of sensor
---
--- ! @var pressure                       stores the pressure returned by the internal
--- !                                     function of sensor
---
--- ! @var  INICIALES                     user's initials, brought from credential.lua   
 ------------------------------------------------------------------------------------
 
 function send_data_grafana(temperature,humidity,pressure,INICIALES)
@@ -64,5 +39,41 @@ function send_data_grafana(temperature,humidity,pressure,INICIALES)
 		end) -- * post function end
 end -- * send_data_grafana end
 
+------------------------------------------------------------------------------------
+-- ! @function send_data_uptime         to read the uptime from the esp32
+-- !                                     and send it by post request 
+------------------------------------------------------------------------------------
 
+function send_data_uptime()
+    local uptime = node.uptime()
+    local data = "uptime,device=cto-bme280 value=" .. tonumber(uptime)
+    local headers = {
+        ["Content-Type"] = "text/plain",
+        ["Authorization"] = "Basic " .. token_grafana
+    }
+
+    http.post(url, { headers = headers }, data,
+        function(code_return, data_return)
+            print("HTTP POST return " .. code_return)
+        end)
+end
+
+------------------------------------------------------------------------------------
+-- ! @function send_data_heap         to read the heap from the esp32
+-- !                                     and send it by post request 
+------------------------------------------------------------------------------------
+
+function send_data_heap()
+local heap = node.heap()
+local data = "heap,device=cto-bme280 value=" .. tonumber(heap)
+local headers = {
+	["Content-Type"] = "text/plain",
+	["Authorization"] = "Basic " .. token_grafana
+}
+
+http.post(url, { headers = headers }, data,
+	function(code_return, data_return)
+			print("HTTP POST return " .. code_return)
+	end)
+end 
 


### PR DESCRIPTION
### Logré crear un panel para el Heap y para el Uptime, pero no para la frecuencia del micro.

#### supuestamente añadieron una funcion para leer la frecuencia del gpu pero esta no aparece en la documentacion oficial

* dejo el [link](https://github.com/nodemcu/nodemcu-firmware/issues/2374) del issue en donde se menciona la funcíon node.cpufreq()
* usé este [modulo](https://nodemcu.readthedocs.io/en/dev-esp32/modules/node/) para traer la informacion

#### tuve problemas a la hora de especificarle a grafana que mida el tiempo en minutos, solo logré dejarlo en ms, adjunto imagen de muestra
[![imagen.png](https://i.postimg.cc/90Gyw0TP/imagen.png)](https://postimg.cc/MfpnhW9X)
